### PR TITLE
feat: Add service account email as an argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,9 @@ Python Runtime (Cloud Functions only)
 Deploy name (Cloud Functions only)
   the name of the deployed function (in GCP) and also in the HTTP path
 
+Service account email (Cloud Functions only)
+  the email of the service account used for the Cloud Function
+
 Pub/Sub topic trigger (Cloud Functions only)
   if you want your function to be triggered by a Cloud Pub/Sub message
 

--- a/infra/serverless/gcf_rules.bzl
+++ b/infra/serverless/gcf_rules.bzl
@@ -88,6 +88,8 @@ def _py_cloud_function_impl(ctx):
   
   gcloud_cmdline.extend(['--entry-point', ctx.attr.entry])
 
+  gcloud_cmdline.extend(['--service-account', ctx.attr.service_account_email])
+
   if ctx.attr.trigger_topic:
     gcloud_cmdline.extend(['--trigger-topic', ctx.attr.trigger_topic])
   elif ctx.attr.trigger_bucket:
@@ -157,6 +159,7 @@ py_cloud_function = rule(
     'gcloud_project': attr.string(),
     'region': attr.string(),
     'deploy_name': attr.string(),
+    'service_account_email': attr.string(mandatory = True),
     'trigger_topic': attr.string(),
     'trigger_bucket': attr.string(),
     'trigger_event': attr.string(),

--- a/infra/serverless/gcf_rules.bzl
+++ b/infra/serverless/gcf_rules.bzl
@@ -88,7 +88,8 @@ def _py_cloud_function_impl(ctx):
   
   gcloud_cmdline.extend(['--entry-point', ctx.attr.entry])
 
-  gcloud_cmdline.extend(['--service-account', ctx.attr.service_account_email])
+  if ctx.attr.service_account_email:
+    gcloud_cmdline.extend(['--service-account', ctx.attr.service_account_email])
 
   if ctx.attr.trigger_topic:
     gcloud_cmdline.extend(['--trigger-topic', ctx.attr.trigger_topic])
@@ -159,7 +160,7 @@ py_cloud_function = rule(
     'gcloud_project': attr.string(),
     'region': attr.string(),
     'deploy_name': attr.string(),
-    'service_account_email': attr.string(mandatory = True),
+    'service_account_email': attr.string(),
     'trigger_topic': attr.string(),
     'trigger_bucket': attr.string(),
     'trigger_event': attr.string(),


### PR DESCRIPTION
Allow service account email to be provided as an argument.

Resources: 
- https://cloud.google.com/functions/docs/securing/function-identity#adding_a_user-managed_service_account_at_deployment
